### PR TITLE
Compile fixes for MSVC 2010

### DIFF
--- a/ykcore/ykcore.c
+++ b/ykcore/ykcore.c
@@ -486,7 +486,7 @@ int yk_read_response_from_key(YK_KEY *yk, uint8_t slot, unsigned int flags,
 	/* The first part of the response was read by yk_wait_for_key_status(). We need
 	 * to copy it to buf.
 	 */
-	memcpy(buf + *bytes_read, data, sizeof(data) - 1);
+	memcpy((char*)buf + *bytes_read, data, sizeof(data) - 1);
 	*bytes_read += sizeof(data) - 1;
 
 	while (*bytes_read + FEATURE_RPT_SIZE <= bufsize) {
@@ -517,7 +517,7 @@ int yk_read_response_from_key(YK_KEY *yk, uint8_t slot, unsigned int flags,
 				return 1;
 			}
 
-			memcpy(buf + *bytes_read, data, sizeof(data) - 1);
+			memcpy((char*)buf + *bytes_read, data, sizeof(data) - 1);
 			*bytes_read += sizeof(data) - 1;
 		} else {
 			/* Reset read mode of Yubikey before returning. */

--- a/ykcore/ykcore_windows.c
+++ b/ykcore/ykcore_windows.c
@@ -32,6 +32,7 @@
 #include "ykdef.h"
 #include "ykcore_backend.h"
 
+#define INITGUID
 #include <stdio.h>
 #include <windows.h>
 #include <setupapi.h>


### PR DESCRIPTION
A few cast errors. See http://support.microsoft.com/kb/130869 for explanation on the use of `#define INITGUID`
