### PR TITLE
Use supported mechanism to set ACL

### DIFF
--- a/69-yubikey-systemd.rules
+++ b/69-yubikey-systemd.rules
@@ -1,0 +1,10 @@
+ACTION!="add|change", GOTO="yubico_end"
+
+# Udev rules for letting the console user access the Yubikey USB
+# device node, needed for challenge/response to work correctly.
+
+# Yubico Yubikey II
+ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010", \
+    ENV{ID_SECURITY_TOKEN}="1"
+
+LABEL="yubico_end"


### PR DESCRIPTION
According to Kay Sievers, one of the systemd / udev developers, in Red
Hat Bugzilla 811691 [1], the udev-acl utility was never meant to be called
directly. In newer versions of systemd, the utility does not even exist
anymore.

The same goes for calling TAG directly in a .rules file.

Kay created a new device class in systemd / udev to label Yubico (and
other challenge / response devices) with, so that the ACL on the device
can be set in a supported way. This class is ID_SECURITY_TOKEN.

The file in this commit sets this class for Yubico devices (or at least,
for my Yubikey II, I don't know the idProduct for devices that I
do not own). This file should be used instead of the current
70-yubikey.rules file on systems that have a new enough systemd / udev
installed, starting with this commit in systemd master:
ff87b7e7486f954a18536bebbd83a81b7e7749b2 [2]

[1] https://bugzilla.redhat.com/show_bug.cgi?id=811691
[2] http://cgit.freedesktop.org/systemd/systemd/commit/?id=ff87b7e7486f954a18536bebbd83a81b7e7749b2
