### PR TITLE
 Added TOTP (6 digits) functionality to ykchalresp.c 

### DIFF
--- a/ykchalresp.c
+++ b/ykchalresp.c
@@ -250,7 +250,7 @@ static int challenge_response(YK_KEY *yk, int slot,
 	/* HMAC responses are 160 bits, Yubico 128 */
 	expect_bytes = (hmac == true) ? 20 : 16;
 
-	if(digits){
+	if(digits && hmac){
 		offset   =  response[19] & 0xf ;
 		bin_code = (response[offset]  & 0x7f) << 24
 		| (response[offset+1] & 0xff) << 16


### PR DESCRIPTION
This should implement TOTP with a fixed time step of 30 seconds and 6 digits output.
