### PR TITLE
Add support for Yubikey U2F on OS X (fixes #65)

### DIFF
--- a/ykcore/ykcore.c
+++ b/ykcore/ykcore.c
@@ -67,10 +67,10 @@ int yk_release(void)
 
 YK_KEY *yk_open_first_key(void)
 {
-	int pids[] = {YUBIKEY_PID, NEO_OTP_PID, NEO_OTP_CCID_PID,
-		NEO_OTP_U2F_PID, NEO_OTP_U2F_CCID_PID, YK4_OTP_PID,
-		YK4_OTP_U2F_PID, YK4_OTP_CCID_PID, YK4_OTP_U2F_CCID_PID,
-		PLUS_U2F_OTP_PID};
+	int pids[] = {YUBIKEY_PID, YUBIKEY_U2F_PID, NEO_OTP_PID,
+		NEO_OTP_CCID_PID, NEO_OTP_U2F_PID, NEO_OTP_U2F_CCID_PID,
+		YK4_OTP_PID, YK4_OTP_U2F_PID, YK4_OTP_CCID_PID,
+		YK4_OTP_U2F_CCID_PID, PLUS_U2F_OTP_PID};
 
 	YK_KEY *yk = _ykusb_open_device(YUBICO_VID, pids, sizeof(pids) / sizeof(int));
 	int rc = yk_errno;

--- a/ykcore/ykcore_osx.c
+++ b/ykcore/ykcore_osx.c
@@ -105,8 +105,12 @@ void *_ykusb_open_device(int vendor_id, int *product_ids, size_t pids_len)
 			long usagePage = _ykosx_getIntProperty( dev, CFSTR( kIOHIDPrimaryUsagePageKey ));
 			long usage = _ykosx_getIntProperty( dev, CFSTR( kIOHIDPrimaryUsageKey ));
 			long devVendorId = _ykosx_getIntProperty( dev, CFSTR( kIOHIDVendorIDKey ));
-			/* usagePage 1 is generic desktop and usage 6 is keyboard */
-			if(usagePage == 1 && usage == 6 && devVendorId == vendor_id) {
+
+			/**
+			 * usagePage 1 is generic desktop and usage 6 is keyboard
+			 * usagePage 0xF1D0 is U2F and with usage 1 (see https://github.com/Yubico/yubikey-personalization/issues/65)
+			 */
+			if(((usagePage == 1 && usage == 6) || (usagePage == 0xF1D0 && usage == 1)) && devVendorId == vendor_id) {
 				long devProductId = _ykosx_getIntProperty( dev, CFSTR( kIOHIDProductIDKey ));
 				size_t j;
 				for(j = 0; j < pids_len; j++) {

--- a/ykcore/ykdef.h
+++ b/ykcore/ykdef.h
@@ -273,6 +273,7 @@ struct status_st {
 
 #define	YUBICO_VID		0x1050	/* Global vendor ID */
 #define	YUBIKEY_PID		0x0010	/* Yubikey (version 1 and 2) */
+#define	YUBIKEY_U2F_PID	0x0120	/* Yubikey U2F (e.g. GitHub promo key) */
 #define	NEO_OTP_PID		0x0110	/* Yubikey NEO - OTP only */
 #define	NEO_OTP_CCID_PID	0x0111	/* Yubikey NEO - OTP and CCID */
 #define	NEO_CCID_PID		0x0112	/* Yubikey NEO - CCID only */


### PR DESCRIPTION
Per the title, this adds support for the U2F sent out as part of the GitHub promotion and fixes #65.