### PR TITLE
Allow Yubico Yubikey NEO in U2F+CCID mode to be used as a security token.

### DIFF
--- a/69-yubikey.rules
+++ b/69-yubikey.rules
@@ -4,7 +4,7 @@ ACTION!="add|change", GOTO="yubico_end"
 # device node, needed for challenge/response to work correctly.
 
 # Yubico Yubikey II
-ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
+ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0115|0116|0401|0403|0405|0407|0410", \
     ENV{ID_SECURITY_TOKEN}="1"
 
 LABEL="yubico_end"

--- a/70-yubikey.rules
+++ b/70-yubikey.rules
@@ -3,6 +3,6 @@
 # device node, needed for challenge/response to work correctly.
 
 ACTION=="add|change", SUBSYSTEM=="usb", \
-  ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
+  ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0115|0116|0401|0403|0405|0407|0410", \
   TEST=="/var/run/ConsoleKit/database", \
   RUN+="udev-acl --action=$env{ACTION} --device=$env{DEVNAME}"


### PR DESCRIPTION
I've disabled the OTP functionality of my NEO-n to prevent accidental brushes of the Yubikey from interfering with my work. My Yubikey appears with a product id that isn't handled by the current udev rules.

Here is the dmesg output when I plug it in.
> usb 1-2: New USB device found, idVendor=1050, idProduct=0115
> hid-generic 0003:1050:0115.0002: hiddev0,hidraw1: USB HID v1.10 Device [Yubico Yubikey NEO U2F+CCID] on usb-0000:00:14.0-2/input0

This simple change makes everything work for me.