### PR TITLE
Add missing idProduct 0404

### DIFF
--- a/69-yubikey.rules
+++ b/69-yubikey.rules
@@ -4,7 +4,7 @@ ACTION!="add|change", GOTO="yubico_end"
 # device node, needed for challenge/response to work correctly.
 
 # Yubico Yubikey II
-ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
+ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0404|0405|0407|0410", \
     ENV{ID_SECURITY_TOKEN}="1"
 
 LABEL="yubico_end"

--- a/70-yubikey.rules
+++ b/70-yubikey.rules
@@ -3,6 +3,6 @@
 # device node, needed for challenge/response to work correctly.
 
 ACTION=="add|change", SUBSYSTEM=="usb", \
-  ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
+  ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0404|0405|0407|0410", \
   TEST=="/var/run/ConsoleKit/database", \
   RUN+="udev-acl --action=$env{ACTION} --device=$env{DEVNAME}"


### PR DESCRIPTION
My Yubikey isn't detected due to a missing idProduct in the udev rules. Although my Fedora only has 69-yubikey.rules I also added it to 70-yubikey.rules
  