### PR TITLE
Gil Kloepfer suggests this quick strlen fix for returning serial_modhex in ykinfo.c

### DIFF
--- a/ykinfo.c
+++ b/ykinfo.c
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
 			}
 			if(serial_modhex) {
 				yubikey_hex_decode(hex_serial, ptr, strlen(ptr));
-				yubikey_modhex_encode(modhex_serial, hex_serial, strlen(hex_serial));
+				yubikey_modhex_encode(modhex_serial, hex_serial, strlen(ptr)/2);
 				if(!quiet)
 					printf("serial_modhex: ");
 				printf("%s\n", modhex_serial);


### PR DESCRIPTION
For these sample device serial number values, strlen() is hitting the null at the end of serial_hex and returning an incorrect length:

serial: 7123200
serial_hex: 6cb100
serial_modhex: hrnb ["cc" is truncated here]

strlen(ptr)/2 returns the correct length, regardless of content.

serial: 7123200
serial_hex: 6cb100
serial_modhex: hrnbcc

Credit to Gil Kloepfer for the fix.