### PR TITLE
Update 70-yubikey.rules

### DIFF
--- a/70-yubikey.rules
+++ b/70-yubikey.rules
@@ -2,7 +2,6 @@
 # Udev rules for letting the console user access the Yubikey USB
 # device node, needed for challenge/response to work correctly.
 
-ACTION=="add|change", SUBSYSTEM=="usb", \
+ACTION=="add|change", SUBSYSTEM=="usb|usbmisc", \
   ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
-  TEST=="/var/run/ConsoleKit/database", \
-  RUN+="udev-acl --action=$env{ACTION} --device=$env{DEVNAME}"
+  TAG+="uaccess"


### PR DESCRIPTION
`yubikey-personalization` requires `/dev/usb/hiddev*`. So this patch adds `usbmisc` to `SUBSYSTEM`.