### PR TITLE
ykcore: the length check should only be done if expect_bytes > 0

### DIFF
--- a/ykcore/ykcore.c
+++ b/ykcore/ykcore.c
@@ -624,16 +624,16 @@ int yk_read_response_from_key(YK_KEY *yk, uint8_t slot, unsigned int flags,
 						yk_errno = YK_ECHECKSUM;
 						return 0;
 					}
-				}
 
-				/* since we get data in chunks of 7 we need to round expect bytes out to the closest higher multiple of 7 */
-				if(expect_bytes % 7 != 0) {
-					expect_bytes += 7 - (expect_bytes % 7);
-				}
+					/* since we get data in chunks of 7 we need to round expect bytes out to the closest higher multiple of 7 */
+					if(expect_bytes % 7 != 0) {
+						expect_bytes += 7 - (expect_bytes % 7);
+					}
 
-				if (*bytes_read != expect_bytes) {
-					yk_errno = YK_EWRONGSIZ;
-					return 0;
+					if (*bytes_read != expect_bytes) {
+						yk_errno = YK_EWRONGSIZ;
+						return 0;
+					}
 				}
 
 				/* Reset read mode of Yubikey before returning. */


### PR DESCRIPTION
this fix ended up on the wrong side of } and was always ran