### PR TITLE
Tighten the salt_len check to avoid a potential stack buf overwrite f…

### DIFF
--- a/ykpbkdf2.c
+++ b/ykpbkdf2.c
@@ -54,7 +54,7 @@ int yk_pbkdf2(const char *passphrase,
 	      unsigned char *dk, size_t dklen,
 	      YK_PRF_METHOD *prf_method)
 {
-	if (salt_len > 256) {
+	if (salt_len > (255 - 4)) {
 		return 0;
 	}
 	size_t l = ((dklen - 1 + prf_method->output_size)


### PR DESCRIPTION
…urther down.

If salt_len was 256:

```
 for (block_count = 1; block_count <= l; block_count++) {
                unsigned char block[256]; /* A big chunk, that's 2048 bits */
[ ... ]

                memcpy(block, salt, salt_len);
                block[salt_len + 0] = (block_count & 0xff000000) >> 24;
                block[salt_len + 1] = (block_count & 0x00ff0000) >> 16;
                block[salt_len + 2] = (block_count & 0x0000ff00) >>  8;
                block[salt_len + 3] = (block_count & 0x000000ff) >>  0;
```
block[256] is outside the buffer and then the next lines would overwrite 3 more bytes