### PR TITLE
Add Security Key NFC to the udev rules

### DIFF
--- a/69-yubikey.rules
+++ b/69-yubikey.rules
@@ -4,7 +4,7 @@ ACTION!="add|change", GOTO="yubico_end"
 # device node, needed for challenge/response to work correctly.
 
 # Yubico Yubikey II
-ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
+ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0120|0401|0403|0405|0407|0410", \
     ENV{ID_SECURITY_TOKEN}="1"
 
 LABEL="yubico_end"

--- a/70-yubikey.rules
+++ b/70-yubikey.rules
@@ -3,6 +3,6 @@
 # device node, needed for challenge/response to work correctly.
 
 ACTION=="add|change", SUBSYSTEM=="usb", \
-  ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
+  ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0120|0401|0403|0405|0407|0410", \
   TEST=="/var/run/ConsoleKit/database", \
   RUN+="udev-acl --action=$env{ACTION} --device=$env{DEVNAME}"


### PR DESCRIPTION
$ lsusb
`ID 1050:0120 Yubico.com Yubikey Touch U2F Security Key`
$ ykman list
`Security Key NFC [FIDO]`

Without this change I'm not able to see the Security Key NFC as a user with ykman and also not via the YubiKey Manager (yubikey-manager-qt).

Without:
`crw------- 1 root root 245, 4 Apr 15 15:56 /dev/hidraw4`
With the ID added.
`crw-rw----+ 1 root root 245, 4 Apr 15 15:59 /dev/hidraw4`
