### PR TITLE
Adds autotools option for building without documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,6 +90,8 @@ ykchalresp_LDADD = ./libykpers-1.la $(LTLIBYUBIKEY)
 ykinfo_SOURCES = ykinfo.c
 ykinfo_LDADD = ./libykpers-1.la $(LTLIBYUBIKEY)
 
+EXTRA_DIST =
+if ENABLE_DOC
 dist_man1_MANS = ykpersonalize.1 ykchalresp.1 ykinfo.1
 DISTCLEANFILES = $(dist_man1_MANS)
 MANSOURCES = ykpersonalize.1.adoc ykchalresp.1.adoc ykinfo.1.adoc
@@ -98,22 +100,24 @@ SUFFIXES = .1.adoc .1
 	$(A2X) -L --format=manpage -a revdate="Version $(VERSION)" --xsltproc-opts="--nonet" $<
 
 # Dist docs
-EXTRA_DIST = doc/Compatibility.asciidoc doc/USB-Hid-Issue.asciidoc
+EXTRA_DIST += doc/Compatibility.asciidoc doc/USB-Hid-Issue.asciidoc
 
 # Dist contrib stuff.
 EXTRA_DIST += contrib/README contrib/programming.sh contrib/oath-unlock-reprogram.sh contrib/draft-josefsson-yubikey-config.xml
 
-# Windows rules.
-EXTRA_DIST += ykpers4win.mk ykpers4mac.mk
-
 # Dist dev tools as well, to have the tarball complete.
 EXTRA_DIST += build-and-test.sh .travis.yml .gitignore
 
-# udev rule files
-EXTRA_DIST += 69-yubikey.rules 70-yubikey.rules
-
 # dist the man sources
 EXTRA_DIST += $(MANSOURCES)
+
+endif
+
+# Windows rules.
+EXTRA_DIST += ykpers4win.mk ykpers4mac.mk
+
+# udev rule files
+EXTRA_DIST += 69-yubikey.rules 70-yubikey.rules
 
 udevrulesdir=@udevrulesdir@
 dist_udevrules_DATA = \

--- a/configure.ac
+++ b/configure.ac
@@ -137,6 +137,14 @@ AC_MSG_CHECKING([whether to use json library])
 AC_MSG_RESULT([$with_json])
 AM_CONDITIONAL([JSON], [test "$with_json" = yes])
 
+# --disable-documentation
+AC_ARG_ENABLE([documentation],
+	      [AS_HELP_STRING([--disable-documentation],
+			     [do not build documentation])],
+			     [enable_doc="${enableval}" ],
+			     [enable_doc="yes"])
+AM_CONDITIONAL(ENABLE_DOC, test "$enable_doc" != "no")
+
 # Check for json_object_to_json_string_ext, needed for pretty printing.
 am_save_CFLAGS="$CFLAGS"
 am_save_LIBS="$LIBS"


### PR DESCRIPTION
- removes a2x dependency used for man page generation by configuring with:
  ./configure --disable-documentation